### PR TITLE
Implement 'Hide Shorts' Feature

### DIFF
--- a/src/components/section/Main.jsx
+++ b/src/components/section/Main.jsx
@@ -6,6 +6,7 @@ import {
   KeyDisplayFullTitle,
   KeyDynamicVideo,
   KeyHideChannelProfile,
+  KeyHideShort,
   KeyPostPerRow,
   KeyShelfItemPerRow,
   KeyVideoPerRow,
@@ -18,12 +19,16 @@ function Main() {
         <p className="bg-content1 dark:bg-background text-small font-semibold pb-2">Home page</p>
         <div className="bg-content1 rounded-lg overflow-hidden">
           <SwitchControl
-            label="Show full video titles"
-            storageKey={KeyDisplayFullTitle}
+            label="Hide shorts"
+            storageKey={KeyHideShort}
           />
           <SwitchControl
             label="Hide channel profile"
             storageKey={KeyHideChannelProfile}
+          />
+          <SwitchControl
+            label="Show full video titles"
+            storageKey={KeyDisplayFullTitle}
           />
           <SwitchControl
             label="Auto-adjust videos per row"
@@ -44,9 +49,8 @@ function Main() {
             label="Shorts per row"
             storageKey={KeyShelfItemPerRow}
             maxValue={12}
-            minValue={0}
+            minValue={1}
             borderBottom={false}
-            zeroValueMessage="⚠ A value of zero disables shorts completely on Home and Subscriptions"
           />
         </div>
       </div>

--- a/src/content-scripts/modules/options/hideShort.js
+++ b/src/content-scripts/modules/options/hideShort.js
@@ -1,0 +1,58 @@
+import { addStyle } from "../utils/addStyle";
+import { KeyHideShort } from "../../../data/storage-key";
+import { removeElementById } from "../utils/removeElement";
+
+// For testing
+// https://www.youtube.com/
+// https://www.youtube.com/feed/subscriptions
+// https://www.youtube.com/results?search_query=shorts
+// https://www.youtube.com/@MrBeast2
+
+export const optionHideShort = (hideShort) => {
+  if (!hideShort) {
+    removeElementById(KeyHideShort);
+    return;
+  }
+
+  addStyle(
+    KeyHideShort,
+    `
+    /* ---- Home Feed ---- */
+    [page-subtype='home'] ytd-rich-section-renderer:has(a[href^="/shorts/"]) {
+      display: none;
+    }
+
+    /* ---- Watch Feed ---- */
+    ytd-watch-grid ytd-rich-shelf-renderer[is-shorts],
+    ytd-watch-flexy ytd-rich-shelf-renderer[is-shorts],
+    ytd-watch-flexy ytd-reel-shelf-renderer {
+      display: none;
+    }
+
+    /* ---- Subscription Feed ---- */
+    [page-subtype="subscriptions"] ytd-item-section-renderer:has(a[href^="/shorts/"]),
+    [page-subtype="subscriptions"] ytd-rich-section-renderer:has(a[href^="/shorts/"]),
+    [page-subtype="subscriptions"] ytd-grid-video-renderer:has(a[href^="/shorts/"]),
+    [page-subtype="subscriptions"] ytd-rich-item-renderer:has(a[href^="/shorts/"]) {
+      display: none;
+    }
+
+    /* ---- Hashtag Feed ---- */
+    [page-subtype="hashtag-landing-page"] ytd-rich-item-renderer:has(a[href^="/shorts/"]) {
+      display: none;
+    }
+
+    /* ---- Channel Feed ---- */
+    [page-subtype="channels"] ytd-item-section-renderer:has(a[href^="/shorts/"]),
+    [page-subtype="channels"] ytd-rich-grid-renderer:has(a[href^="/shorts/"]) {
+      display: none;
+    }
+
+    /*  ---- Search Feed ---- */
+    ytd-search ytd-reel-shelf-renderer:has(a[href^="/shorts/"]),
+    ytd-search ytd-video-renderer:has(a[href^="/shorts/"]) {
+      display: none;
+    }
+  `
+  );
+};

--- a/src/content-scripts/modules/options/optionsChanges.js
+++ b/src/content-scripts/modules/options/optionsChanges.js
@@ -1,14 +1,17 @@
 import {
   KeyDisplayFullTitle,
   KeyHideChannelProfile,
+  KeyHideShort,
   KeyVideoPerRow,
 } from "../../../data/storage-key";
 import { optionDisplayFullTitle } from "./displayFullTitle";
 import { optionHideChannelProfile } from "./hideChannelProfile";
+import { optionHideShort } from "./hideShort";
 import { optionSkeletonPerRow } from "./skeletonPerRow";
 
 export const injectAllChanges = (data) => {
   optionHideChannelProfile(data[KeyHideChannelProfile]);
   optionDisplayFullTitle(data[KeyDisplayFullTitle]);
   optionSkeletonPerRow(data[KeyVideoPerRow]);
+  optionHideShort(data[KeyHideShort]);
 };

--- a/src/content-scripts/modules/options/shortsPerRow.js
+++ b/src/content-scripts/modules/options/shortsPerRow.js
@@ -3,25 +3,13 @@ import { KeyShelfItemPerRow } from "../../../data/storage-key";
 import { removeElementById } from "../utils/removeElement";
 
 export const optionShortsPerRow = (amount) => {
-  if (amount === 0) {
-    addStyle(
-      KeyShelfItemPerRow,
-      `
-      ytd-rich-shelf-renderer[is-shorts] {
-        display: none !important;
-      }
-      `
-    );
-    return;
-  }
-
   addStyle(
     KeyShelfItemPerRow,
     `
     ytd-rich-shelf-renderer[is-shorts] ytd-rich-item-renderer[is-slim-media] {
       width: calc(100%/var(--ytd-rich-grid-slim-items-per-row) - var(--ytd-rich-grid-item-margin) - 0.01px) !important;
     }
-    
+    ytd-rich-shelf-renderer[is-shorts][is-show-less-hidden] ytd-rich-item-renderer[is-slim-media]:nth-child(-n + ${amount}),
     ytd-rich-shelf-renderer[is-shorts][is-show-more-hidden] ytd-rich-item-renderer[is-slim-media]:nth-child(-n + ${amount}) {
       display: block !important;
     }

--- a/src/data/storage-key.js
+++ b/src/data/storage-key.js
@@ -4,6 +4,7 @@ export const KeyExtensionTheme = "extensionTheme";
 
 // Main Page
 export const KeyHideChannelProfile = "hideChannelProfile";
+export const KeyHideShort = "hideShort";
 export const KeyDisplayFullTitle = "displayFullTitle";
 export const KeyDynamicVideo = "dynamicVideoPerRow";
 export const KeyVideoPerRow = "videoPerRow";
@@ -20,6 +21,7 @@ export const settingKey = [
 
   KeyDynamicVideo,
   KeyHideChannelProfile,
+  KeyHideShort,
   KeyDisplayFullTitle,
   KeyVideoPerRow,
   KeyPostPerRow,
@@ -35,6 +37,7 @@ export const defaultSetting = {
 
   [KeyDynamicVideo]: false,
   [KeyHideChannelProfile]: true,
+  [KeyHideShort]: false,
   [KeyDisplayFullTitle]: false,
   [KeyVideoPerRow]: 5,
   [KeyPostPerRow]: 3,


### PR DESCRIPTION
https://github.com/sapondanaisriwan/youtube-row-fixer/issues/45

Some users prefer not to see Shorts content. This feature improves user experience by providing more control over visible content.

Changes Made
- Fixed an issue where setting "Shorts per row" to 0 and navigating to a Short would cause the UI to freeze.
- Added the ability to hide Shorts on the following pages by just one click:
  - Home
  - Channel
  - Search
  - Watch
  - Subscriptions
  - Hashtag

![krCABfWKBe](https://github.com/user-attachments/assets/99d9ef95-730f-4ed9-84a6-534df280c4fa)
